### PR TITLE
Undeprecate the user spec, and general cleanup

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,21 +2,21 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   it 'has a valid factory' do
-    create(:user).should be_valid
+    expect(build :user).to be_valid
   end
   it 'is invalid without a first_name' do
-    build(:user, first_name: nil).should_not be_valid
+    expect(build :user, first_name: nil).not_to be_valid
   end
   it 'is invalid without a last_name' do
-    build(:user, last_name: nil).should_not be_valid
+    expect(build :user, last_name: nil).not_to be_valid
   end
   it 'is invalid without an email' do
-    build(:user, email: nil).should_not be_valid
+    expect(build :user, email: nil).not_to be_valid
   end
   it 'is invalid without a phone' do
-    build(:user, phone: nil).should_not be_valid
+    expect(build :user, phone: nil).not_to be_valid
   end
   it 'is invalid without a spire_id' do
-    build(:user, spire_id: nil).should_not be_valid
+    expect(build :user, spire_id: nil).not_to be_valid
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,25 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  it "has a valid factory" do
+  it 'has a valid factory' do
     create(:user).should be_valid
   end
-  it "is invalid without a first_name" do
+  it 'is invalid without a first_name' do
     build(:user, first_name: nil).should_not be_valid
   end
-  it "is invalid without a last_name" do
+  it 'is invalid without a last_name' do
     build(:user, last_name: nil).should_not be_valid
   end
-  it "is invalid without an email" do
+  it 'is invalid without an email' do
     build(:user, email: nil).should_not be_valid
   end
-  it "is invalid without a phone" do
+  it 'is invalid without a phone' do
     build(:user, phone: nil).should_not be_valid
   end
-  it "is invalid without a spire_id" do
+  it 'is invalid without a spire_id' do
     build(:user, spire_id: nil).should_not be_valid
   end
-  
-  describe ''
-  it "returns a contact's full name as a string"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ require 'factory_girl_rails'
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.raise_errors_for_deprecations!
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
Replace should with expect, and raise errors when should is used.
Use single quotes unless double quotes are needed, and omit parentheses for unchained method calls. (I'll probably open a PR incorporating Rubocop.)
Use `build` for all the specs to keep them consistent. Remove unused `describe`.