### PR TITLE
reinstate the state machine

### DIFF
--- a/app/models/rental.rb
+++ b/app/models/rental.rb
@@ -11,40 +11,40 @@ class Rental < ActiveRecord::Base
   validates :start_date, date: { after_or_equal_to: Time.zone.today, message: 'must be no earlier than today' }
   validates :end_date, date: { after_or_equal_to: :start_date, message: 'must be no earlier than today' }
 
-  # aasm column: :rental_status do
-  #   state :reserved, initial: true
-  #   state :checked_out
-  #   state :checked_in
-  #   state :inspected
-  #   state :available
-  #   state :canceled
+  aasm column: :rental_status do
+    state :reserved, initial: true
+    state :checked_out
+    state :checked_in
+    state :inspected
+    state :available
+    state :canceled
 
-  #   event :cancel do
-  #     transitions from: :reserved, to: :canceled
-  #   end
+    event :cancel do
+      transitions from: :reserved, to: :canceled
+    end
 
-  #   event :pickup do
-  #     transitions from: :reserved, to: :checked_out
-  #     after do
-  #       update(checked_out_at: Time.zone.now)
-  #     end
-  #   end
+    event :pickup do
+      transitions from: :reserved, to: :checked_out
+      after do
+        update(checked_out_at: Time.zone.now)
+      end
+    end
 
-  #   event :return do
-  #     transitions from: :checked_out, to: :checked_in
-  #     after do
-  #       update(checked_in_at: Time.zone.now)
-  #     end
-  #   end
+    event :return do
+      transitions from: :checked_out, to: :checked_in
+      after do
+        update(checked_in_at: Time.zone.now)
+      end
+    end
 
-  #   event :inspect do
-  #     transitions from: :checked_in, to: :inspected
-  #   end
+    event :approve do
+      transitions from: :checked_in, to: :inspected
+    end
 
-  #   event :process do
-  #     transitions from: [:inspected, :canceled], to: :available
-  #   end
-  # end
+    event :process do
+      transitions from: [:inspected, :canceled], to: :available
+    end
+  end
 
   def create_reservation
     return false unless mostly_valid?

--- a/db/migrate/20160217192112_create_rentals.rb
+++ b/db/migrate/20160217192112_create_rentals.rb
@@ -1,7 +1,7 @@
 class CreateRentals < ActiveRecord::Migration
   def change
     create_table :rentals do |t|
-      t.string :rental_status
+      t.string :rental_status, null: false
       t.integer :user_id, null: false
       t.integer :department_id
       t.integer :reservation_id, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 20160222142237) do
   end
 
   create_table "rentals", force: :cascade do |t|
-    t.string   "rental_status",  limit: 255
+    t.string   "rental_status",  limit: 255, null: false
     t.integer  "user_id",        limit: 4,   null: false
     t.integer  "department_id",  limit: 4
     t.integer  "reservation_id", limit: 4,   null: false

--- a/spec/models/rental_spec.rb
+++ b/spec/models/rental_spec.rb
@@ -49,44 +49,44 @@ RSpec.describe Rental do
     end
   end
 
-  # describe 'rental_status' do
-  #   let(:rental) { create :rental }
+  describe 'rental_status' do
+    let(:rental) { create :rental }
 
-  #   it 'is reserved upon creation' do
-  #     expect(rental).to be_reserved
-  #   end
+    it 'is reserved upon creation' do
+      expect(rental).to be_reserved
+    end
 
-  #   it 'is canceled after cancel' do
-  #     rental.cancel!
-  #     expect(rental).to be_canceled
-  #   end
+    it 'is canceled after cancel' do
+      rental.cancel!
+      expect(rental).to be_canceled
+    end
 
-  #   it 'is checked_out after pickup' do
-  #     rental.pickup!
-  #     expect(rental.checked_out_at).not_to be_nil
-  #     expect(rental).to be_checked_out
-  #   end
+    it 'is checked_out after pickup' do
+      rental.pickup!
+      expect(rental.checked_out_at).not_to be_nil
+      expect(rental).to be_checked_out
+    end
 
-  #   it 'is checked_in after return' do
-  #     rental.pickup
-  #     rental.return!
-  #     expect(rental.checked_in_at).not_to be_nil
-  #     expect(rental).to be_checked_in
-  #   end
+    it 'is checked_in after return' do
+      rental.pickup
+      rental.return!
+      expect(rental.checked_in_at).not_to be_nil
+      expect(rental).to be_checked_in
+    end
 
-  #   it 'is inspected after inspect' do
-  #     rental.pickup
-  #     rental.return
-  #     rental.inspect!
-  #     expect(rental).to be_inspected
-  #   end
+    it 'is inspected after approve' do
+      rental.pickup
+      rental.return
+      rental.approve!
+      expect(rental).to be_inspected
+    end
 
-  #   it 'is available after process' do
-  #     rental.pickup
-  #     rental.return
-  #     rental.inspect
-  #     rental.process!
-  #     expect(rental).to be_available
-  #   end
-  # end
+    it 'is available after process' do
+      rental.pickup
+      rental.return
+      rental.approve
+      rental.process!
+      expect(rental).to be_available
+    end
+  end
 end


### PR DESCRIPTION
Fixes #36. Rename transition "inspect" to "approve" as the former must be a reserved word.