### PR TITLE
Adding rental controller specs

### DIFF
--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 97.0
+    "covered_percent": 97.1
   }
 }

--- a/spec/controllers/rentals_controller_spec.rb
+++ b/spec/controllers/rentals_controller_spec.rb
@@ -117,8 +117,7 @@ describe RentalsController do
     end
 
     it 'remains canceled if already canceled' do
-      delete :destroy, id: @rental.id
-      expect(@rental.reload.canceled?).to be true
+      @rental.cancel!
       delete :destroy, id: @rental.id
       expect(@rental.reload.canceled?).to be true
     end


### PR DESCRIPTION
Referencing issue #65 
- Both controller coverages are at 100% after this addition according to coverage/index.html