### PR TITLE
Addresses an issue with failing application helper specs, post rails 5 migration

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,4 +47,8 @@ Rails.application.configure do
 
   # inventory api uri
   config.inventory_api_uri = 'http://localhost:4000/v1/'
+
+  config.after_initialize do
+    Rails.application.routes.default_url_options[:host] = 'localhost:3000'
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,4 +42,8 @@ Rails.application.configure do
 
   # inventory api uri
   config.inventory_api_uri = 'http://localhost:4000/v1/'
+
+  config.after_initialize do
+    Rails.application.routes.default_url_options[:host] = 'localhost:3000'
+  end
 end

--- a/config/environments/test.travis.rb
+++ b/config/environments/test.travis.rb
@@ -42,4 +42,8 @@ Rails.application.configure do
 
   # inventory api uri
   config.inventory_api_uri = 'https://aggressive-epsilon.herokuapp.com/v1/'
+
+  config.after_initialize do
+    Rails.application.routes.default_url_options[:host] = 'localhost:3000'
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe ApplicationHelper do
+  include Rails.application.routes.url_helpers
+
   let!(:user) { create(:user) }
 
   before(:each) { current_user }


### PR DESCRIPTION
* Adds route helper explicitly
* Sets a default URL for development and test