### PR TITLE
Fixing issue with unfriendly error when rental creation fails

### DIFF
--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -76,11 +76,16 @@ class RentalsController < ApplicationController
 
     @start_date = params['start_date'] || Time.zone.today
 
-    if @rental.save
+    if @rental.create_reservation && @rental.save
       flash[:success] = 'You have succesfully reserved your Rental!'
       redirect_to(@rental)
     else # error has problem, cannot rental a error message here
-      @rental.errors.full_messages.each { |e| flash_message :warning, e, :now }
+      set_users
+      if @rental.item_type_id.present? && Rental.where(item_type_id: @rental.item_type_id).count == Item.where(item_type_id: @rental.item_type_id).count
+        flash[:danger] = "#{ItemType.find(@rental.item_type_id).name} is unavailable for this date."
+      else
+        flash[:danger] = 'Something went wrong. Please try again.'
+      end
       render :new
     end
   end

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 99.22
+    "covered_percent": 99.18
   }
 }

--- a/spec/controllers/rentals_controller_spec.rb
+++ b/spec/controllers/rentals_controller_spec.rb
@@ -86,7 +86,7 @@ describe RentalsController do
           post :create, params: { rental: invalid_create }
         end.to_not change(Rental, :count)
       end
-      it 're-renders the :new template' do
+      it 're-renders the :new template with a generic warning message' do
         post :create, params: { rental: invalid_create }
         expect(response).to render_template :new
       end


### PR DESCRIPTION
This fixes the issue addressed in #164 
- Tells user if the item type they requested is not available. If this is not the issue, it gives a generic flash warning.