### PR TITLE
update renter references from rental.user to rental.renter

### DIFF
--- a/app/controllers/holds_controller.rb
+++ b/app/controllers/holds_controller.rb
@@ -22,7 +22,7 @@ class HoldsController < ApplicationController
       flash[:warning] = 'Error creating Hold'
       render :new
     end
-    @hold.check_conflicting_rentals
+    @hold.handle_conflicting_rentals
   end
 
   def edit; end
@@ -35,7 +35,7 @@ class HoldsController < ApplicationController
       flash[:warning] = 'Error updating Hold'
       render :edit
     end
-    @hold.check_conflicting_rentals
+    @hold.handle_conflicting_rentals
   end
 
   def lift

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -10,7 +10,7 @@ class Hold < ActiveRecord::Base
   validates :start_time, :end_time, date: { after: Date.current, message: 'must be after current date. ' }
   validates :end_time, date: { after: :start_time, message: 'must be after start time' }
 
-  def check_conflicting_rentals
+  def handle_conflicting_rentals
     conflicting_rentals = Rental.where('start_time >= :hold_start_time AND end_time <= :hold_end_time',
                                        hold_start_time: start_time,
                                        hold_end_time: end_time)
@@ -23,7 +23,7 @@ class Hold < ActiveRecord::Base
                             renter_id: curr_rental.renter_id, department_id: curr_rental.department_id,
                             start_time: curr_rental.start_time, end_time: curr_rental.end_time)
     new_rental.create_reservation
-    new_rental.save
+    new_rental.save!
     curr_rental.cancel!
     ReplacementMailer.replacement_email(curr_rental.renter, self, curr_rental, new_rental).deliver_now
   rescue

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -20,15 +20,15 @@ class Hold < ActiveRecord::Base
 
   def replace_rental(curr_rental)
     new_rental = Rental.create(item_type_id: curr_rental.item_type_id,
-                               user_id: curr_rental.user_id, department_id: curr_rental.department_id,
+                               user_id: curr_rental.renter_id, department_id: curr_rental.department_id,
                                start_time: curr_rental.start_time, end_time: curr_rental.end_time)
 
     curr_rental.cancel
     curr_rental.save
-    ReplacementMailer.replacement_email(curr_rental.user, self, curr_rental, new_rental).deliver_now
+    ReplacementMailer.replacement_email(curr_rental.renter, self, curr_rental, new_rental).deliver_now
   rescue
     errors.add(:item_id, ': failed to replace existing rentals for this item')
-    ReplacementMailer.no_replacement_email(curr_rental.user, self, curr_rental).deliver_now
+    ReplacementMailer.no_replacement_email(curr_rental.renter, self, curr_rental).deliver_now
   end
 
   def start_hold

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -19,12 +19,12 @@ class Hold < ActiveRecord::Base
   end
 
   def replace_rental(curr_rental)
-    new_rental = Rental.create(item_type_id: curr_rental.item_type_id,
-                               user_id: curr_rental.renter_id, department_id: curr_rental.department_id,
-                               start_time: curr_rental.start_time, end_time: curr_rental.end_time)
-
-    curr_rental.cancel
-    curr_rental.save
+    new_rental = Rental.new(item_type_id: curr_rental.item_type_id, creator_id: curr_rental.creator_id,
+                            renter_id: curr_rental.renter_id, department_id: curr_rental.department_id,
+                            start_time: curr_rental.start_time, end_time: curr_rental.end_time)
+    new_rental.create_reservation
+    new_rental.save
+    curr_rental.cancel!
     ReplacementMailer.replacement_email(curr_rental.renter, self, curr_rental, new_rental).deliver_now
   rescue
     errors.add(:item_id, ': failed to replace existing rentals for this item')

--- a/app/views/rentals/drop_off.html.erb
+++ b/app/views/rentals/drop_off.html.erb
@@ -14,7 +14,7 @@
     <td><%= rental.item_type.name%></td>
     <td><%= rental.item.name%></td>
     <td><%= number_to_currency(rental.financial_transaction.amount) %></td>
-    <td><%= rental.user.full_name %></td>
+    <td><%= rental.renter.full_name %></td>
     <td><%= rental.department.name %></td>
     <td><%= rental.start_time.to_date %></td>
     <td><%= rental.end_time.to_date %></td>

--- a/app/views/rentals/no_show_form.html.erb
+++ b/app/views/rentals/no_show_form.html.erb
@@ -14,7 +14,7 @@
     <td><%= rental.item_type.name%></td>
     <td><%= rental.item.name%></td>
     <td><%= number_to_currency(rental.financial_transaction.amount) %></td>
-    <td><%= rental.user.full_name %></td>
+    <td><%= rental.renter.full_name %></td>
     <td><%= rental.department.name %></td>
     <td><%= rental.start_time.to_date %></td>
     <td><%= rental.end_time.to_date %></td>

--- a/app/views/rentals/pickup.html.erb
+++ b/app/views/rentals/pickup.html.erb
@@ -14,7 +14,7 @@
     <td><%= rental.item_type.name%></td>
     <td><%= rental.item.name%></td>
     <td><%= number_to_currency(rental.financial_transaction.amount) %></td>
-    <td><%= rental.user.full_name %></td>
+    <td><%= rental.renter.full_name %></td>
     <td><%= rental.department.name %></td>
     <td><%= rental.start_time.to_date %></td>
     <td><%= rental.end_time.to_date %></td>

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 98.23
+    "covered_percent": 98.48
   }
 }

--- a/spec/factories/rental.rb
+++ b/spec/factories/rental.rb
@@ -46,6 +46,11 @@ FactoryGirl.define do
     end_time (Time.current + 5.days).to_s
   end
 
+  factory :hold_conflicting_rental, parent: :mock_rental do
+    start_time Time.current + 1.day
+    end_time Time.current + 2.days
+  end
+
   factory :past_rental, parent: :mock_rental do
     rental_status 'dropped_off'
   end

--- a/spec/models/hold_spec.rb
+++ b/spec/models/hold_spec.rb
@@ -40,36 +40,43 @@ RSpec.describe Hold, type: :model do
     end
   end
 
-  describe 'check_conflicting_rentals' do
+  describe 'handle_conflicting_rentals' do
     let(:hold) { create(:hold) }
     let(:conflicting_rental) { create(:hold_conflicting_rental) }
     let(:future_rental) { create(:far_future_rental) }
 
     it 'should cancel a conflicting rental' do
       conflicting_rental
-      hold.check_conflicting_rentals
+      hold.handle_conflicting_rentals
       expect(conflicting_rental.reload).to be_canceled
     end
 
     it 'should not affect a future rental' do
       future_rental
       expect do
-        hold.check_conflicting_rentals
+        hold.handle_conflicting_rentals
       end.not_to change(future_rental, :rental_status)
     end
 
     it 'should create a new rental when there is a conflicting rental' do
       conflicting_rental
       expect do
-        hold.check_conflicting_rentals
+        hold.handle_conflicting_rentals
       end.to change(Rental, :count).by(1)
     end
 
     it 'should not create a new rental when there is not a conflicting rental' do
       future_rental
       expect do
-        hold.check_conflicting_rentals
+        hold.handle_conflicting_rentals
       end.to change(Rental, :count).by(0)
+    end
+
+    it 'should send an email when there is a conflicting rental' do
+      conflicting_rental
+      expect do
+        hold.handle_conflicting_rentals
+      end.to change { ActionMailer::Base.deliveries.size }.by(1)
     end
   end
 end

--- a/spec/models/hold_spec.rb
+++ b/spec/models/hold_spec.rb
@@ -39,4 +39,37 @@ RSpec.describe Hold, type: :model do
       expect(build(:invalid_date_time_hold)).not_to be_valid
     end
   end
+
+  describe 'check_conflicting_rentals' do
+    let(:hold) { create(:hold) }
+    let(:conflicting_rental) { create(:hold_conflicting_rental) }
+    let(:future_rental) { create(:far_future_rental) }
+
+    it 'should cancel a conflicting rental' do
+      conflicting_rental
+      hold.check_conflicting_rentals
+      expect(conflicting_rental.reload).to be_canceled
+    end
+
+    it 'should not affect a future rental' do
+      future_rental
+      expect do
+        hold.check_conflicting_rentals
+      end.not_to change(future_rental, :rental_status)
+    end
+
+    it 'should create a new rental when there is a conflicting rental' do
+      conflicting_rental
+      expect do
+        hold.check_conflicting_rentals
+      end.to change(Rental, :count).by(1)
+    end
+
+    it 'should not create a new rental when there is not a conflicting rental' do
+      future_rental
+      expect do
+        hold.check_conflicting_rentals
+      end.to change(Rental, :count).by(0)
+    end
+  end
 end


### PR DESCRIPTION
There were a few lingering references to rental.user in the app after #213, causing an error on rental processing pages and elsewhere. This updates them from rental.user->rental.renter. Please double check that none of them were supposed to refer to the creator of the rental.