### PR TITLE
Fix back buttons on show pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -117,4 +117,9 @@ class ApplicationController < ActionController::Base
       (params[:controller] == 'home' && params[:action] == 'index') ||
       params[:action] == 'render_404'
   end
+
+  def store_return_to
+    # save the current url for use by back buttons
+    session[:return_to] = request.original_url
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,6 +85,11 @@ class ApplicationController < ActionController::Base
     false
   end
 
+  def set_return_url
+    # save the current url for use by back buttons
+    session[:return_url] = request.original_url
+  end
+
   private
 
   def send_error_email(error)
@@ -116,10 +121,5 @@ class ApplicationController < ActionController::Base
     (params[:controller] == 'application' && params[:action] == 'root') ||
       (params[:controller] == 'home' && params[:action] == 'index') ||
       params[:action] == 'render_404'
-  end
-
-  def store_return_to
-    # save the current url for use by back buttons
-    session[:return_to] = request.original_url
   end
 end

--- a/app/controllers/damages_controller.rb
+++ b/app/controllers/damages_controller.rb
@@ -2,6 +2,8 @@
 class DamagesController < ApplicationController
   before_action :find_damage, only: [:show, :edit, :update]
 
+  after_action :set_return_url, only: [:index]
+
   def show; end
 
   def index

--- a/app/controllers/departments_controller.rb
+++ b/app/controllers/departments_controller.rb
@@ -2,6 +2,8 @@
 class DepartmentsController < ApplicationController
   before_action :set_department, only: [:show, :edit, :update, :destroy, :remove_user]
 
+  after_action :set_return_url, only: [:index, :show]
+
   def index
     @departments = Department.all
   end

--- a/app/controllers/financial_transactions_controller.rb
+++ b/app/controllers/financial_transactions_controller.rb
@@ -2,6 +2,8 @@
 class FinancialTransactionsController < ApplicationController
   before_action :set_financial_transaction, only: [:show, :edit]
 
+  after_action :set_return_url, only: [:index]
+
   # GET /financial_transactions
   def index
     @q = FinancialTransaction.search(params[:q])

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,6 +2,8 @@
 class GroupsController < ApplicationController
   before_action :set_group, only: [:show, :edit, :update, :destroy, :update_permission, :remove_permission, :remove_user, :enable_user, :enable_permission]
 
+  after_action :set_return_url, only: [:index]
+
   def index
     @groups = Group.all
   end

--- a/app/controllers/holds_controller.rb
+++ b/app/controllers/holds_controller.rb
@@ -3,6 +3,8 @@ class HoldsController < ApplicationController
   include ApplicationHelper
   before_action :set_hold, only: [:show, :edit, :update, :destroy, :lift]
 
+  after_action :set_return_url, only: [:index]
+
   def show; end
 
   def index

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class HomeController < ApplicationController
+  before_action :store_return_to, only: [:index]
+  
   @per_page = 5
 
   def index

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class HomeController < ApplicationController
-  before_action :store_return_to, only: [:index]
-  
+  after_action :set_return_url, only: [:index]
+
   @per_page = 5
 
   def index

--- a/app/controllers/incidental_types_controller.rb
+++ b/app/controllers/incidental_types_controller.rb
@@ -3,6 +3,8 @@ class IncidentalTypesController < ApplicationController
   before_action :set_incidental_type, only: [:edit, :update, :destroy, :show]
   before_action :set_rentals, only: [:new, :edit, :create, :update]
 
+  after_action :set_return_url, only: [:index]
+
   def index
     @incidental_types = IncidentalType.all
   end

--- a/app/controllers/incurred_incidentals_controller.rb
+++ b/app/controllers/incurred_incidentals_controller.rb
@@ -4,6 +4,8 @@ class IncurredIncidentalsController < ApplicationController
   before_action :set_incidental_types, only: [:new, :edit, :create, :update]
   before_action :set_rentals, only: [:new, :edit, :create, :update]
 
+  after_action :set_return_url, only: [:index]
+
   def show
     @incurred_incidental = IncurredIncidental.find(params[:id])
   end

--- a/app/controllers/item_types_controller.rb
+++ b/app/controllers/item_types_controller.rb
@@ -2,6 +2,8 @@
 class ItemTypesController < ApplicationController
   before_action :set_item_type, only: [:show, :edit, :update]
 
+  after_action :set_return_url, only: [:index]
+
   def index
     @item_types = ItemType.all
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :edit, :update]
+  before_action :store_return_to, only: [:index]
 
   def index
     @item_types = ItemType.all

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :edit, :update]
-  before_action :store_return_to, only: [:index]
+
+  after_action :set_return_url, only: [:index]
 
   def index
     @item_types = ItemType.all

--- a/app/controllers/payment_tracking_controller.rb
+++ b/app/controllers/payment_tracking_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class PaymentTrackingController < ApplicationController
+  after_action :set_return_url, only: [:index]
+
   def index
     params[:q] ||= {}
 

--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -10,6 +10,8 @@ class RentalsController < ApplicationController
   before_action :set_incidental_types, only: [:new]
   before_action :set_financial_transactions, only: [:show, :invoice]
 
+  before_action :store_return_to, only: [:index, :processing]
+
   # GET /rentals
   def index
     @q = rentals_visible_to_current_user.search(params[:q])

--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -10,7 +10,7 @@ class RentalsController < ApplicationController
   before_action :set_incidental_types, only: [:new]
   before_action :set_financial_transactions, only: [:show, :invoice]
 
-  before_action :store_return_to, only: [:index, :processing]
+  after_action :set_return_url, only: [:index, :processing]
 
   # GET /rentals
   def index

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,8 @@ class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy, :enable]
   before_action :set_department
 
+  after_action :set_return_url, only: [:index]
+
   def index
     @users = User.all
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,6 +35,13 @@ module ApplicationHelper
     # raise "Link not rendered for omni user, please check this" if @current_user.groups.find_by(name: "omni").present?
   end
 
+  def link_back(name = nil, default_path = nil, html_options = nil, &block)
+    if session.has_key? :return_url
+      return_url = session[:return_url]
+    end
+    link_to(name, return_url || default_path, html_options, &block)
+  end
+
   def button_to(*_args)
     raise 'Button to is not protected by permissions'
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,9 +36,7 @@ module ApplicationHelper
   end
 
   def link_back(name = nil, default_path = nil, html_options = nil, &block)
-    if session.has_key? :return_url
-      return_url = session[:return_url]
-    end
+    return_url = session[:return_url] if session.key? :return_url
     link_to(name, return_url || default_path, html_options, &block)
   end
 

--- a/app/views/damages/show.html.erb
+++ b/app/views/damages/show.html.erb
@@ -44,6 +44,6 @@
       <%= link_to 'Create Hold', new_hold_path(damage_id: @damage, item_id: @damage.item), class: "btn btn-primary"%>
     <% end %>
     <%= link_to 'View Incurred Incidental', @damage.incurred_incidental, class: "btn btn-success"%>
-    <%= link_to 'Back', :back, class: "btn btn-default" %>
+    <%= link_back 'Back', damages_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/departments/show.html.erb
+++ b/app/views/departments/show.html.erb
@@ -2,7 +2,7 @@
 
 <h5>
   <%= link_to 'Edit Department', edit_department_path(@department), class: "btn btn-primary" %>
-  <%= link_to 'Back', :back, class: "btn btn-default" %>
+  <%= link_back 'Back', departments_path, class: "btn btn-default" %>
 </h5>
 
 <h3>Users</h3>

--- a/app/views/financial_transactions/show.html.erb
+++ b/app/views/financial_transactions/show.html.erb
@@ -1,4 +1,4 @@
 <p id="notice"><%= notice %></p>
 
 <%= link_to 'Edit', edit_financial_transaction_path(@financial_transaction) %> |
-<%= link_to 'Back', :back, class: 'btn btn-default' %>
+<%= link_back 'Back', financial_transactions_path, class: 'btn btn-default' %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -3,7 +3,7 @@
 
 <h5>
   <%= link_to 'Edit Group', edit_group_path(@group), class: "btn btn-primary" %>
-  <%= link_to 'Back', :back, class: "btn btn-default" %>
+  <%= link_back 'Back', groups_path, class: "btn btn-default" %>
 </h5>
 
 <h3>Permissions</h3>

--- a/app/views/holds/show.html.erb
+++ b/app/views/holds/show.html.erb
@@ -33,6 +33,6 @@
 <div class="form-group col-xs-12">
   <div class="col-xs-offset-2 col-xs-10">
     <%= link_to 'Edit Hold', edit_hold_path(@hold), class: "btn btn-primary" %>
-    <%= link_to 'Back', :back, class: "btn btn-default" %>
+    <%= link_back 'Back', holds_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/incidental_types/show.html.erb
+++ b/app/views/incidental_types/show.html.erb
@@ -18,6 +18,6 @@
 <div class="form-group col-xs-12">
   <div class="col-xs-offset-2 col-xs-10">
     <%= link_to 'Edit Incidental Type', edit_incidental_type_path(@incidental_type), class: "btn btn-primary" %>
-    <%= link_to 'Back', :back, class: "btn btn-default" %>
+    <%= link_back 'Back', incidental_types_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/incurred_incidentals/show.html.erb
+++ b/app/views/incurred_incidentals/show.html.erb
@@ -119,6 +119,6 @@
       <% end %>
     <% end %>
     <%= link_to 'View Incidental Type', incidental_type_path(@incurred_incidental.incidental_type), class: "btn btn-success" %>
-    <%= link_to 'Back', :back, class: "btn btn-default" %>
+    <%= link_back 'Back', incurred_incidentals_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/item_types/show.html.erb
+++ b/app/views/item_types/show.html.erb
@@ -13,6 +13,6 @@
 <div class="form-group col-xs-12">
   <div class="col-xs-offset-2 col-xs-10">
     <%= link_to 'Edit Item Type', edit_item_type_path(@item_type), class: "btn btn-primary" %>
-    <%= link_to 'Back', :back, class: "btn btn-default" %>
+    <%= link_back 'Back', item_types_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -14,6 +14,6 @@
   <div class="col-xs-offset-2 col-xs-10">
     <%= link_to 'Edit Item', edit_item_path(@item), class: "btn btn-primary" %>
     <%= link_to 'Delete Item', { :controller => "items", :action => "destroy" }, method: :delete, data: { :confirm => 'Are you sure?' }, class: 'btn btn-danger' %>
-    <%= link_to 'Back', session[:return_to] || items_path, class: "btn btn-default" %>
+    <%= link_back 'Back', items_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -14,6 +14,6 @@
   <div class="col-xs-offset-2 col-xs-10">
     <%= link_to 'Edit Item', edit_item_path(@item), class: "btn btn-primary" %>
     <%= link_to 'Delete Item', { :controller => "items", :action => "destroy" }, method: :delete, data: { :confirm => 'Are you sure?' }, class: 'btn btn-danger' %>
-    <%= link_to 'Back', :back, class: "btn btn-default" %>
+    <%= link_to 'Back', session[:return_to] || items_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/rentals/show.html.erb
+++ b/app/views/rentals/show.html.erb
@@ -97,6 +97,6 @@
     <% if @rental.balance != 0 %>
       <%= link_to 'Process Payment', new_financial_transaction_path(rental_id: @rental.id, transactable_type: Payment.name), class: "btn btn-primary"%>
     <% end %>
-    <%= link_to 'Back', session[:return_to] || rentals_path, class: "btn btn-default" %>
+    <%= link_back 'Back', rentals_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/rentals/show.html.erb
+++ b/app/views/rentals/show.html.erb
@@ -97,6 +97,6 @@
     <% if @rental.balance != 0 %>
       <%= link_to 'Process Payment', new_financial_transaction_path(rental_id: @rental.id, transactable_type: Payment.name), class: "btn btn-primary"%>
     <% end %>
-    <%= link_to 'Back', :back, class: "btn btn-default" %>
+    <%= link_to 'Back', session[:return_to] || rentals_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,6 +28,6 @@
 <div class="form-group col-xs-12">
   <div class="col-xs-offset-2 col-xs-10">
     <%= link_to 'Edit User', edit_user_path(@user), class: "btn btn-primary" %>
-    <%= link_to 'Back', :back, class: "btn btn-default" %>
+    <%= link_back 'Back', users_path, class: "btn btn-default" %>
   </div>
 </div>


### PR DESCRIPTION
Should fix #300. On index actions the set_return_url is called, storing the url of the index page in the session. This is later grabbed by the show view to render the back button for the correct index page. 

There are multiple indexes for the same model, such as `home` and `rentals` which both can show rentals, which is why the index url is stored in the session.

There are still some cases where the back buttons are broken, such as when javascript does not catch an error in the field, so there is a redirect to the same page, meaning the back button is now pointing to the same page, not the previous one.