### PR TITLE
fix price calculation on rental#new bug

### DIFF
--- a/app/assets/javascripts/rentals/new.js.erb
+++ b/app/assets/javascripts/rentals/new.js.erb
@@ -54,7 +54,9 @@ function costCalculation(){
       },
       error: function () { alert('failed to retreive rental cost'); }
     });
-   }
+  } else {
+    amount.val("0");
+  }
 }
 
 $(document).ready(function () {


### PR DESCRIPTION
if you add a couple items, allow cost to calculate, then remove all of those items.  The cost will be left at an incorrect value and not reset to zero.