### PR TITLE
Rental cancel fix

### DIFF
--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -172,7 +172,7 @@ class RentalsController < ApplicationController
   def destroy
     if @rental.may_cancel?
       @rental.cancel!
-      @rental.delete_reservation
+      @rental.delete_reservations
       flash[:success] = 'Rental Canceled.'
     elsif @rental.canceled?
       flash[:warning] = 'Rental Has Already Been Canceled'

--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -172,7 +172,6 @@ class RentalsController < ApplicationController
   def destroy
     if @rental.may_cancel?
       @rental.cancel!
-      @rental.delete_reservations
       flash[:success] = 'Rental Canceled.'
     elsif @rental.canceled?
       flash[:warning] = 'Rental Has Already Been Canceled'

--- a/app/models/rental.rb
+++ b/app/models/rental.rb
@@ -155,7 +155,7 @@ class Rental < ActiveRecord::Base
     return true if end_time < Time.current # deleting it is pointless, it wont inhibit new rentals and it will destroy a record.
     rentals_items.each do |ri|
       next if ri.reservation_id.nil? # nothing to delete here
-      errors.add(:rentals_items, "Failed to delete reservation (uuid #{ri.reservation_id})") unless delete_reservation(ri.reservation_id)
+      errors.add(:rentals_items, "Failed to delete reservation (uuid #{ri.reservation_id})") unless delete_reservation(ri.reservation_id).nil?
       ri.reservation_id = nil
     end
     throw(:abort) if errors.any? # abort a #destroy

--- a/app/models/rental.rb
+++ b/app/models/rental.rb
@@ -155,7 +155,7 @@ class Rental < ActiveRecord::Base
     return true if end_time < Time.current # deleting it is pointless, it wont inhibit new rentals and it will destroy a record.
     rentals_items.each do |ri|
       next if ri.reservation_id.nil? # nothing to delete here
-      errors.add(:rentals_items, "Failed to delete reservation (uuid #{ri.reservation_id})") unless delete_reservation(ri.reservation_id).nil?
+      errors.add(:rentals_items, "Failed to delete reservation (uuid #{ri.reservation_id})") unless delete_reservation(ri.reservation_id)
       ri.reservation_id = nil
     end
     throw(:abort) if errors.any? # abort a #destroy

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   # inventory api uri
-  config.inventory_api_uri = 'https://aggressive-epsilon.herokuapp.com/v1/' # 'http://localhost:4000/v1/' 
+  config.inventory_api_uri = 'http://localhost:4000/v1/' # 'https://aggressive-epsilon.herokuapp.com/v1/'
 
 
   config.after_initialize do

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 99.37
+    "covered_percent": 99.39
   }
 }


### PR DESCRIPTION
### Closes #372 

(Alternative solution than #373 for #372)

There was an unnecessary call to delete_reservations in the rental controller destroy method. The rental model has a callback assigned to `before_destroy` that already handles the deleting of reservations, calling it twice was causing errors to be thrown.

Also changed the inventory api to localhost for ease of development