### PR TITLE
Fixed references to old model relations 'rental.item_type' and 'rental.item'

### DIFF
--- a/app/views/incurred_incidentals/index.html.erb
+++ b/app/views/incurred_incidentals/index.html.erb
@@ -10,7 +10,7 @@
   </tr>
   <% @incurred_incidentals.each do |incurred_incidental| %>
     <tr>
-      <td><%= incurred_incidental.rental.item_type.name %></td>
+      <td><%= incurred_incidental.rental.str_item_types %></td>
       <td><%= incurred_incidental.rental.start_date.to_date %></td>
       <td><%= incurred_incidental.rental.end_date.to_date %></td>
       <td><%= incurred_incidental.incidental_type.name %></td>

--- a/app/views/rentals/drop_off.html.erb
+++ b/app/views/rentals/drop_off.html.erb
@@ -11,8 +11,8 @@
     <th>Rental End Date</th>
   </tr>
   <tr>
-    <td><%= rental.item_type.name%></td>
-    <td><%= rental.item.name%></td>
+    <td><%= rental.str_item_types%></td>
+    <td><%= rental.str_items%></td>
     <td><%= number_to_currency(rental.financial_transaction.amount) %></td>
     <td><%= rental.renter.full_name %></td>
     <td><%= rental.department.name %></td>

--- a/app/views/rentals/no_show_form.html.erb
+++ b/app/views/rentals/no_show_form.html.erb
@@ -11,8 +11,8 @@
     <th>Rental End Date</th>
   </tr>
   <tr>
-    <td><%= rental.item_type.name%></td>
-    <td><%= rental.item.name%></td>
+    <td><%= rental.str_item_types%></td>
+    <td><%= rental.str_items%></td>
     <td><%= number_to_currency(rental.financial_transaction.amount) %></td>
     <td><%= rental.renter.full_name %></td>
     <td><%= rental.department.name %></td>

--- a/app/views/rentals/pickup.html.erb
+++ b/app/views/rentals/pickup.html.erb
@@ -11,8 +11,8 @@
     <th>Rental End Date</th>
   </tr>
   <tr>
-    <td><%= rental.item_type.name%></td>
-    <td><%= rental.item.name%></td>
+    <td><%= rental.str_item_types %></td>
+    <td><%= rental.str_items%></td>
     <td><%= number_to_currency(rental.financial_transaction.amount) %></td>
     <td><%= rental.renter.full_name %></td>
     <td><%= rental.department.name %></td>


### PR DESCRIPTION
### Closes #377 

Ran a search through the codebase for `rental.item_type` and `rental.item` and replaced them with `rental.str_item_types` and `rental.str_items` accordingly (two pre-existing model methods).