### PR TITLE
Integrate persistent active job backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ before_script:
   - bundle exec rake db:migrate
   - bundle exec rake db:seed
   - export TZ="America/New_York"
+  - bundle exec sidekiq -d -L /tmp/sidekiq.log
+services:
+  - redis-server
 addons:
   code_climate:
     repo_token: 15ed3ea3aa5e152f478928dbb01e5747253e54be2b90553170931dbc842428c7

--- a/Capfile
+++ b/Capfile
@@ -24,6 +24,7 @@ require 'capistrano/rails'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 require 'capistrano/passenger'
+require 'capistrano/sidekiq'
 
 # Load custom tasks from `lib/capistrano/tasks' if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ gem 'coffee-rails', '~> 4.1.0'
 gem 'therubyracer', platform: :ruby
 
 # Persistant queuing backend
-gem 'sidekiq'
 gem 'capistrano-sidekiq'
+gem 'sidekiq'
 
 # Interaction with jquery and controller without refreshing page
 gem 'fullcalendar-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'therubyracer', platform: :ruby
 
 # Persistant queuing backend
 gem 'sidekiq'
+gem 'capistrano-sidekiq'
 
 # Interaction with jquery and controller without refreshing page
 gem 'fullcalendar-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,9 @@ GEM
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
+    capistrano-sidekiq (0.10.0)
+      capistrano
+      sidekiq (>= 3.4)
     capistrano-stats (1.1.1)
     codeclimate-test-reporter (1.0.5)
       simplecov
@@ -347,6 +350,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails (~> 1.1)
   capistrano-rvm
+  capistrano-sidekiq
   codeclimate-test-reporter
   coffee-rails (~> 4.1.0)
   date_validator

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,9 +80,6 @@ GEM
     capistrano-rails (1.2.2)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capistrano-sidekiq (0.10.0)
       capistrano
       sidekiq (>= 3.4)
@@ -349,7 +346,6 @@ DEPENDENCIES
   capistrano (~> 3.3.0)
   capistrano-passenger
   capistrano-rails (~> 1.1)
-  capistrano-rvm
   capistrano-sidekiq
   codeclimate-test-reporter
   coffee-rails (~> 4.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,8 +191,8 @@ GEM
     pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
-    rack (2.0.1)
-    rack-protection (2.0.0)
+    rack (2.0.4)
+    rack-protection (2.0.1)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)

--- a/app/models/financial_transaction.rb
+++ b/app/models/financial_transaction.rb
@@ -15,6 +15,6 @@ class FinancialTransaction < ActiveRecord::Base
   end
 
   def send_updated_invoice
-    InvoiceMailer.send_invoice(rental).deliver_later
+    InvoiceMailer.send_invoice(rental).deliver_later(wait: 1.minute)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   # inventory api uri
-  config.inventory_api_uri = 'https://aggressive-epsilon.herokuapp.com/v1/' # 'http://localhost:4000/v1/' 
+  config.inventory_api_uri = 'http://localhost:4000/v1/' # 'https://aggressive-epsilon.herokuapp.com/v1/' 
 
 
   config.after_initialize do


### PR DESCRIPTION
### Closes #374 

Installed sidekiq gem. Works fine in development, will need extra work in production. Both sidekiq and redis need to be running alongside the app. There are a number of ways to achieve this including [the capistrano gem](https://github.com/seuros/capistrano-sidekiq) or making our own scripts on the production server. 

[Useful link](https://github.com/mperham/sidekiq/wiki/Deployment)
