### PR TITLE
Deploy fix

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -5,24 +5,8 @@ require 'capistrano/setup'
 # Include default deployment tasks
 require 'capistrano/deploy'
 
-# Include tasks from other gems included in your Gemfile
-#
-# For documentation on these, see for example:
-#
-#   https://github.com/capistrano/rvm
-#   https://github.com/capistrano/rbenv
-#   https://github.com/capistrano/chruby
-#   https://github.com/capistrano/bundler
-#   https://github.com/capistrano/rails
-#   https://github.com/capistrano/passenger
-#
-require 'capistrano/rvm'
-# require 'capistrano/rbenv'
-# require 'capistrano/chruby'
 require 'capistrano/bundler'
 require 'capistrano/rails'
-require 'capistrano/rails/assets'
-require 'capistrano/rails/migrations'
 require 'capistrano/passenger'
 
 # Load custom tasks from `lib/capistrano/tasks' if you have any defined

--- a/Gemfile
+++ b/Gemfile
@@ -80,10 +80,10 @@ end
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'better_errors'
-  gem 'web-console', '~> 2.0'
   gem 'capistrano', '~> 3.3.0'
   gem 'capistrano-passenger'
   gem 'capistrano-rails', '~> 1.1'
+  gem 'web-console', '~> 2.0'
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/Gemfile
+++ b/Gemfile
@@ -58,12 +58,6 @@ gem 'will_paginate-bootstrap'
 # searchable pages
 gem 'ransack'
 
-# deployment
-gem 'capistrano', '~> 3.3.0'
-gem 'capistrano-passenger'
-gem 'capistrano-rails', '~> 1.1'
-gem 'capistrano-rvm'
-
 gem 'unicode_utils', '~> 1.4'
 
 # permanent records
@@ -87,6 +81,9 @@ group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'better_errors'
   gem 'web-console', '~> 2.0'
+  gem 'capistrano', '~> 3.3.0'
+  gem 'capistrano-passenger'
+  gem 'capistrano-rails', '~> 1.1'
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,9 +80,6 @@ GEM
     capistrano-rails (1.2.2)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capistrano-stats (1.1.1)
     codeclimate-test-reporter (1.0.5)
       simplecov
@@ -337,7 +334,6 @@ DEPENDENCIES
   capistrano (~> 3.3.0)
   capistrano-passenger
   capistrano-rails (~> 1.1)
-  capistrano-rvm
   codeclimate-test-reporter
   coffee-rails (~> 4.1.0)
   date_validator

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -4,17 +4,9 @@ lock '3.3.5'
 set :application, 'probable-engine'
 set :repo_url, 'git@github.com:umts/probable-engine.git'
 set :deploy_to, '/var/www/probable-engine'
-set :rvm_type, :system
+set :migration_role, :app
+
 set :linked_files, %w{config/database.yml config/config.yml config/secrets.yml config/inventory_api_keys.yml}
 SSHKit.config.umask = '002'
 remote_user = Net::SSH::Config.for('umaps-web2.oit.umass.edu')[:user] || ENV['USER']
 set :tmp_dir, "/tmp/#{remote_user}"
-
-namespace :deploy do
-  task :restart do
-    on roles(:web), in: :sequence, wait: 5 do
-      # this is magic which lets passenger know it is supposed to restart when it can
-      execute :touch, release_path.join("tmp/restart.txt")
-    end
-  end
-end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -4,7 +4,7 @@
 # is considered to be the first unless any hosts have the primary
 # property set.  Don't declare `role :all`, it's a meta role.
 
-role :web, %w{umaps-web2.oit.umass.edu}
+# role :web, %w{umaps-web2.oit.umass.edu}
 
 
 # Extended Server Syntax
@@ -13,7 +13,7 @@ role :web, %w{umaps-web2.oit.umass.edu}
 # server list. The second argument is a, or duck-types, Hash and is
 # used to set extended properties on the server.
 
-# server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
+server 'umaps-web2.oit.umass.edu', roles: %w{web app}
 
 
 # Custom SSH Options


### PR DESCRIPTION
Migrations will run when capistrano deploys, now.

Went onto the server and installed passenger properly (not as a gem).

Removed RVM from the server, there's no need to ruby version manage when you have one app per server.

Anyone in the 'capistrano' group on the server can deploy.

The real test to see whether this works will be if anyone other than me can deploy now.