### PR TITLE
View cleanup

### DIFF
--- a/app/views/rentals/index.html.erb
+++ b/app/views/rentals/index.html.erb
@@ -13,44 +13,28 @@
 <div id='calendar'></div>
 </br>
 <h1>List of Rentals</h1>
-<%= search_form_for @q, class: 'form-inline' do |f| %>
-  <div class="row">
-    <div class="form-group col-xs-4">
-      <%= label_tag :item_type_id_in, 'Containing Item Types', class: 'col-xs-6' %>
+  <%= search_form_for @q, class: 'form-inline' do |f| %>
+      <%= label_tag :item_type_id_in, 'Containing Item Types'%>
       <%= select_tag :item_type_id_in, options_from_collection_for_select(@item_types.order(name: :asc), "id", "name", selected: params[:item_type_id_in]),
-            multiple: true, include_blank: true, class: "selectpicker form-control col-xs-8" %>
-    </div>
+            multiple: true, include_blank: true, class: "selectpicker form-control col-xs-2" %> <br></br>
 
-    <div class="form-group col-xs-4">
-      <%= label_tag :item_id_in, 'Containing Items', class: 'col-xs-4' %>
+      <%= label_tag :item_id_in, 'Containing Items' %>
       <%= select_tag :item_id_in, options_from_collection_for_select(@items.order(name: :asc), "id", "name", selected: params[:item_id_in]),
-            multiple: true, include_blank: true, class: "selectpicker form-control col-xs-8" %>
-    </div>
+            multiple: true, include_blank: true, class: "selectpicker form-control col-xs-2" %><br></br>
 
-    <div class="form-group col-xs-4">
-      <%= f.label :renter_id_eq, 'Customer', class: 'col-xs-4' %>
+      <%= f.label :renter_id_eq, 'Customer'%>
       <%= f.select :renter_id_eq,
             options_from_collection_for_select(@users.order(first_name: :asc), "id", "full_name", selected: (params[:q].try(:[], :renter_id_eq) || 0)),
-            {include_blank: true}, class: "selectpicker form-control col-xs-8" %>
-    </div>
-  </div>
+            {include_blank: true}, class: "selectpicker form-control col-xs-2" %> <br></br>
 
-  <div class="row">
-    <div class="form-group col-xs-6">
-      <%= f.label :start_time_gteq, 'Between', class: 'col-xs-4' %>
-      <%= f.date_field :start_time_gteq, class: 'form-control col-xs-8' %>
-    </div>
+      <%= f.label :start_time_gteq, 'Between' %>
+      <%= f.date_field :start_time_gteq, class: 'form-control' %>
 
-    <div class="form-group col-xs-6">
-      <%= f.label :end_time_lteq, 'And', class: 'col-xs-4' %>
-      <%= f.date_field :end_time_lteq, class: 'form-control col-xs-8' %>
-    </div>
+      <%= f.label :end_time_lteq, 'And' %>
+      <%= f.date_field :end_time_lteq, class: 'form-control ' %>
 
-    <div class="col-xs-2">
-      <%= f.submit class: "btn btn-default" %>
-    </div>
-  </div>
-<% end %>
+      <%= f.submit class: "btn btn-primary" %>
+    <% end %>
 <br>
 
 <%= render partial: 'table', locals: { rentals: @rentals } %>

--- a/app/views/rentals/processing.html.erb
+++ b/app/views/rentals/processing.html.erb
@@ -3,15 +3,15 @@
 <%= search_form_for @q, url: '/rentals/processing', class: 'form-inline' do |f| %>
   <%= label_tag :item_type_id_in, 'Containing Item Types' %>
   <%= select_tag :item_type_id_in, options_from_collection_for_select(@item_types.order(name: :asc), "id", "name", selected: params[:item_type_id_in]),
-    multiple: true, include_blank: true, class: "selectpicker form-control col-xs-2" %>
+    multiple: true, include_blank: true, class: "selectpicker form-control col-xs-2" %> <br></br>
 
   <%= label_tag :item_id_in, 'Containing Items' %>
   <%= select_tag :item_id_in, options_from_collection_for_select(@items.order(name: :asc), "id", "name", selected: params[:item_id_in]),
-    multiple: true, include_blank: true, class: "selectpicker form-control col-xs-2" %>
-
+    multiple: true, include_blank: true, class: "selectpicker form-control col-xs-2" %> <br></br>
 
   <%= f.label :renter_id_eq, 'Customer' %>
-  <%= f.select :renter_id_eq, options_from_collection_for_select(@users.order(first_name: :asc), "id", "full_name", selected: (params[:q].try(:[], :renter_id_eq) || 0)), {include_blank: true}, class: "selectpicker form-control col-xs-2" %>
+  <%= f.select :renter_id_eq, options_from_collection_for_select(@users.order(first_name: :asc), "id", "full_name", selected: (params[:q].try(:[], :renter_id_eq) || 0)),
+    {include_blank: true}, class: "selectpicker form-control col-xs-2" %> <br></br>
 
   <%= f.label :start_time_gteq, 'Between' %>
   <%= f.date_field :start_time_gteq, class: "form-control" %>

--- a/app/views/rentals/processing.html.erb
+++ b/app/views/rentals/processing.html.erb
@@ -19,7 +19,7 @@
   <%= f.label :end_time_lteq, 'And' %>
   <%= f.date_field :end_time_lteq, class: "form-control" %>
 
-  <%= f.submit class: "btn btn-default"%>
+  <%= f.submit class: "btn btn-primary"%>
 <% end %>
 <br>
 


### PR DESCRIPTION
Resolves Issue #393 

In the rentals processing/processing page.
I changed the search button to fit in with the buttons on the other forms.

I also spaced out the form so the pickers weren't on top of each other and now they each have their own line. Open to suggestions on how to do it a different way, I just thought it looked good this way.