### PR TITLE
Improve back buttons

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -117,9 +117,4 @@ class ApplicationController < ActionController::Base
       (params[:controller] == 'home' && params[:action] == 'index') ||
       params[:action] == 'render_404'
   end
-
-  def set_return_url
-    # save the current url for use by back buttons
-    session[:return_url] = request.original_url
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,11 +85,6 @@ class ApplicationController < ActionController::Base
     false
   end
 
-  def set_return_url
-    # save the current url for use by back buttons
-    session[:return_url] = request.original_url
-  end
-
   private
 
   def send_error_email(error)
@@ -121,5 +116,10 @@ class ApplicationController < ActionController::Base
     (params[:controller] == 'application' && params[:action] == 'root') ||
       (params[:controller] == 'home' && params[:action] == 'index') ||
       params[:action] == 'render_404'
+  end
+
+  def set_return_url
+    # save the current url for use by back buttons
+    session[:return_url] = request.original_url
   end
 end

--- a/app/controllers/damages_controller.rb
+++ b/app/controllers/damages_controller.rb
@@ -2,7 +2,7 @@
 class DamagesController < ApplicationController
   before_action :find_damage, only: [:show, :edit, :update]
 
-  after_action :set_return_url, only: [:index, :new, :edit]
+  after_action :set_return_url, only: %i[index new edit]
 
   def show; end
 

--- a/app/controllers/damages_controller.rb
+++ b/app/controllers/damages_controller.rb
@@ -2,7 +2,7 @@
 class DamagesController < ApplicationController
   before_action :find_damage, only: [:show, :edit, :update]
 
-  after_action :set_return_url, only: [:index]
+  after_action :set_return_url, only: [:index, :new, :edit]
 
   def show; end
 

--- a/app/controllers/damages_controller.rb
+++ b/app/controllers/damages_controller.rb
@@ -2,8 +2,6 @@
 class DamagesController < ApplicationController
   before_action :find_damage, only: [:show, :edit, :update]
 
-  after_action :set_return_url, only: %i[index new edit]
-
   def show; end
 
   def index

--- a/app/controllers/departments_controller.rb
+++ b/app/controllers/departments_controller.rb
@@ -2,7 +2,7 @@
 class DepartmentsController < ApplicationController
   before_action :set_department, only: [:show, :edit, :update, :destroy, :remove_user]
 
-  after_action :set_return_url, only: [:index, :show, :new, :edit]
+  after_action :set_return_url, only: %i[index show new edit]
 
   def index
     @departments = Department.all

--- a/app/controllers/departments_controller.rb
+++ b/app/controllers/departments_controller.rb
@@ -2,7 +2,7 @@
 class DepartmentsController < ApplicationController
   before_action :set_department, only: [:show, :edit, :update, :destroy, :remove_user]
 
-  after_action :set_return_url, only: [:index, :show]
+  after_action :set_return_url, only: [:index, :show, :new, :edit]
 
   def index
     @departments = Department.all

--- a/app/controllers/departments_controller.rb
+++ b/app/controllers/departments_controller.rb
@@ -2,8 +2,6 @@
 class DepartmentsController < ApplicationController
   before_action :set_department, only: [:show, :edit, :update, :destroy, :remove_user]
 
-  after_action :set_return_url, only: %i[index show new edit]
-
   def index
     @departments = Department.all
   end

--- a/app/controllers/financial_transactions_controller.rb
+++ b/app/controllers/financial_transactions_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class FinancialTransactionsController < ApplicationController
-  after_action :set_return_url, only: %i[index new]
 
   def index
     # workaround for unknown Ransack bug

--- a/app/controllers/financial_transactions_controller.rb
+++ b/app/controllers/financial_transactions_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class FinancialTransactionsController < ApplicationController
-  after_action :set_return_url, only: [:index, :new]
+  after_action :set_return_url, only: %i[index new]
 
   def index
     # workaround for unknown Ransack bug

--- a/app/controllers/financial_transactions_controller.rb
+++ b/app/controllers/financial_transactions_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class FinancialTransactionsController < ApplicationController
-  after_action :set_return_url, only: [:index]
+  after_action :set_return_url, only: [:index, :new]
 
   def index
     # workaround for unknown Ransack bug

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,8 +2,6 @@
 class GroupsController < ApplicationController
   before_action :set_group, only: [:show, :edit, :update, :destroy, :update_permission, :remove_permission, :remove_user, :enable_user, :enable_permission]
 
-  after_action :set_return_url, only: %i[index new edit]
-
   def index
     @groups = Group.all
   end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,7 +2,7 @@
 class GroupsController < ApplicationController
   before_action :set_group, only: [:show, :edit, :update, :destroy, :update_permission, :remove_permission, :remove_user, :enable_user, :enable_permission]
 
-  after_action :set_return_url, only: [:index]
+  after_action :set_return_url, only: [:index, :new, :edit]
 
   def index
     @groups = Group.all

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,7 +2,7 @@
 class GroupsController < ApplicationController
   before_action :set_group, only: [:show, :edit, :update, :destroy, :update_permission, :remove_permission, :remove_user, :enable_user, :enable_permission]
 
-  after_action :set_return_url, only: [:index, :new, :edit]
+  after_action :set_return_url, only: %i[index new edit]
 
   def index
     @groups = Group.all

--- a/app/controllers/holds_controller.rb
+++ b/app/controllers/holds_controller.rb
@@ -3,8 +3,6 @@ class HoldsController < ApplicationController
   include ApplicationHelper
   before_action :set_hold, only: [:show, :edit, :update, :destroy, :lift]
 
-  after_action :set_return_url, only: %i[index new edit]
-
   def show; end
 
   def index

--- a/app/controllers/holds_controller.rb
+++ b/app/controllers/holds_controller.rb
@@ -3,7 +3,7 @@ class HoldsController < ApplicationController
   include ApplicationHelper
   before_action :set_hold, only: [:show, :edit, :update, :destroy, :lift]
 
-  after_action :set_return_url, only: [:index, :new, :edit]
+  after_action :set_return_url, only: %i[index new edit]
 
   def show; end
 

--- a/app/controllers/holds_controller.rb
+++ b/app/controllers/holds_controller.rb
@@ -3,7 +3,7 @@ class HoldsController < ApplicationController
   include ApplicationHelper
   before_action :set_hold, only: [:show, :edit, :update, :destroy, :lift]
 
-  after_action :set_return_url, only: [:index]
+  after_action :set_return_url, only: [:index, :new, :edit]
 
   def show; end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class HomeController < ApplicationController
-  after_action :set_return_url, only: [:index]
 
   @per_page = 5
 

--- a/app/controllers/incidental_types_controller.rb
+++ b/app/controllers/incidental_types_controller.rb
@@ -3,7 +3,7 @@ class IncidentalTypesController < ApplicationController
   before_action :set_incidental_type, only: [:edit, :update, :destroy, :show]
   before_action :set_rentals, only: [:new, :edit, :create, :update]
 
-  after_action :set_return_url, only: [:index]
+  after_action :set_return_url, only: [:index, :new, :edit]
 
   def index
     @incidental_types = IncidentalType.all

--- a/app/controllers/incidental_types_controller.rb
+++ b/app/controllers/incidental_types_controller.rb
@@ -3,7 +3,7 @@ class IncidentalTypesController < ApplicationController
   before_action :set_incidental_type, only: [:edit, :update, :destroy, :show]
   before_action :set_rentals, only: [:new, :edit, :create, :update]
 
-  after_action :set_return_url, only: [:index, :new, :edit]
+  after_action :set_return_url, only: %i[index new edit]
 
   def index
     @incidental_types = IncidentalType.all

--- a/app/controllers/incidental_types_controller.rb
+++ b/app/controllers/incidental_types_controller.rb
@@ -3,8 +3,6 @@ class IncidentalTypesController < ApplicationController
   before_action :set_incidental_type, only: [:edit, :update, :destroy, :show]
   before_action :set_rentals, only: [:new, :edit, :create, :update]
 
-  after_action :set_return_url, only: %i[index new edit]
-
   def index
     @incidental_types = IncidentalType.all
   end

--- a/app/controllers/incurred_incidentals_controller.rb
+++ b/app/controllers/incurred_incidentals_controller.rb
@@ -4,7 +4,7 @@ class IncurredIncidentalsController < ApplicationController
   before_action :set_incidental_types, only: [:new, :edit, :create, :update]
   before_action :set_rentals, only: [:new, :edit, :create, :update]
 
-  after_action :set_return_url, only: [:index, :new, :edit]
+  after_action :set_return_url, only: %i[index new edit]
 
   def show
     @incurred_incidental = IncurredIncidental.find(params[:id])

--- a/app/controllers/incurred_incidentals_controller.rb
+++ b/app/controllers/incurred_incidentals_controller.rb
@@ -4,7 +4,7 @@ class IncurredIncidentalsController < ApplicationController
   before_action :set_incidental_types, only: [:new, :edit, :create, :update]
   before_action :set_rentals, only: [:new, :edit, :create, :update]
 
-  after_action :set_return_url, only: [:index]
+  after_action :set_return_url, only: [:index, :new, :edit]
 
   def show
     @incurred_incidental = IncurredIncidental.find(params[:id])

--- a/app/controllers/incurred_incidentals_controller.rb
+++ b/app/controllers/incurred_incidentals_controller.rb
@@ -4,8 +4,6 @@ class IncurredIncidentalsController < ApplicationController
   before_action :set_incidental_types, only: [:new, :edit, :create, :update]
   before_action :set_rentals, only: [:new, :edit, :create, :update]
 
-  after_action :set_return_url, only: %i[index new edit]
-
   def show
     @incurred_incidental = IncurredIncidental.find(params[:id])
   end

--- a/app/controllers/item_types_controller.rb
+++ b/app/controllers/item_types_controller.rb
@@ -2,7 +2,7 @@
 class ItemTypesController < ApplicationController
   before_action :set_item_type, only: [:show, :edit, :update]
 
-  after_action :set_return_url, only: [:index, :new_item_type, :edit]
+  after_action :set_return_url, only: %i[index new_item_type edit]
 
   def index
     @item_types = ItemType.all

--- a/app/controllers/item_types_controller.rb
+++ b/app/controllers/item_types_controller.rb
@@ -2,8 +2,6 @@
 class ItemTypesController < ApplicationController
   before_action :set_item_type, only: [:show, :edit, :update]
 
-  after_action :set_return_url, only: %i[index new_item_type edit]
-
   def index
     @item_types = ItemType.all
   end

--- a/app/controllers/item_types_controller.rb
+++ b/app/controllers/item_types_controller.rb
@@ -2,7 +2,7 @@
 class ItemTypesController < ApplicationController
   before_action :set_item_type, only: [:show, :edit, :update]
 
-  after_action :set_return_url, only: [:index]
+  after_action :set_return_url, only: [:index, :new_item_type, :edit]
 
   def index
     @item_types = ItemType.all

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,8 +2,6 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :edit, :update]
 
-  after_action :set_return_url, only: %i[index new_item edit]
-
   def index
     @item_types = ItemType.all
     @q = Item.search(params[:q])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :edit, :update]
 
-  after_action :set_return_url, only: [:index, :new_item, :edit]
+  after_action :set_return_url, only: %i[index new_item edit]
 
   def index
     @item_types = ItemType.all

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :edit, :update]
 
-  after_action :set_return_url, only: [:index]
+  after_action :set_return_url, only: [:index, :new_item, :edit]
 
   def index
     @item_types = ItemType.all

--- a/app/controllers/payment_tracking_controller.rb
+++ b/app/controllers/payment_tracking_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class PaymentTrackingController < ApplicationController
-  after_action :set_return_url, only: [:index]
 
   def index
     params[:q] ||= {}

--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -10,7 +10,7 @@ class RentalsController < ApplicationController
   before_action :set_incidental_types, only: [:new]
   before_action :set_financial_transactions, only: [:show, :invoice]
 
-  after_action :set_return_url, only: [:index, :new, :edit]
+  after_action :set_return_url, only: %i[index new]
 
   # GET /rentals
   def index

--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -10,8 +10,6 @@ class RentalsController < ApplicationController
   before_action :set_incidental_types, only: [:new]
   before_action :set_financial_transactions, only: [:show, :invoice]
 
-  after_action :set_return_url, only: %i[index new]
-
   # GET /rentals
   def index
     # first pull out the rentals that match our two fields that are not done through ransack

--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -10,7 +10,7 @@ class RentalsController < ApplicationController
   before_action :set_incidental_types, only: [:new]
   before_action :set_financial_transactions, only: [:show, :invoice]
 
-  after_action :set_return_url, only: [:index, :processing]
+  after_action :set_return_url, only: [:index, :new, :edit]
 
   # GET /rentals
   def index

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,8 +3,6 @@ class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy, :enable]
   before_action :set_department
 
-  after_action :set_return_url, only: %i[index new edit]
-
   def index
     @users = User.all
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy, :enable]
   before_action :set_department
 
-  after_action :set_return_url, only: [:index, :new, :edit]
+  after_action :set_return_url, only: %i[index new edit]
 
   def index
     @users = User.all

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy, :enable]
   before_action :set_department
 
-  after_action :set_return_url, only: [:index]
+  after_action :set_return_url, only: [:index, :new, :edit]
 
   def index
     @users = User.all

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,11 +35,6 @@ module ApplicationHelper
     # raise "Link not rendered for omni user, please check this" if @current_user.groups.find_by(name: "omni").present?
   end
 
-  def link_back(name = nil, default_path = nil, html_options = nil, &block)
-    return_url = session[:return_url] if session.key? :return_url
-    link_to(name, return_url || default_path, html_options, &block)
-  end
-
   def button_to(*_args)
     raise 'Button to is not protected by permissions'
   end

--- a/app/views/damages/_form.html.erb
+++ b/app/views/damages/_form.html.erb
@@ -65,7 +65,6 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_back 'Back', damages_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/damages/_form.html.erb
+++ b/app/views/damages/_form.html.erb
@@ -65,7 +65,7 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_to 'Back', :back, class: 'btn btn-default' %>
+      <%= link_back 'Back', damages_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/damages/show.html.erb
+++ b/app/views/damages/show.html.erb
@@ -44,6 +44,5 @@
       <%= link_to 'Create Hold', new_hold_path(damage_id: @damage, item_id: @damage.item), class: "btn btn-primary"%>
     <% end %>
     <%= link_to 'View Incurred Incidental', @damage.incurred_incidental, class: "btn btn-success"%>
-    <%= link_back 'Back', damages_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/departments/_form.html.erb
+++ b/app/views/departments/_form.html.erb
@@ -10,7 +10,7 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_to 'Back', :back, class: 'btn btn-default' %>
+      <%= link_back 'Back', departments_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/departments/_form.html.erb
+++ b/app/views/departments/_form.html.erb
@@ -10,7 +10,6 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_back 'Back', departments_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/departments/show.html.erb
+++ b/app/views/departments/show.html.erb
@@ -2,7 +2,6 @@
 
 <h5>
   <%= link_to 'Edit Department', edit_department_path(@department), class: "btn btn-primary" %>
-  <%= link_back 'Back', departments_path, class: "btn btn-default" %>
 </h5>
 
 <h3>Users</h3>

--- a/app/views/financial_transactions/_form.html.erb
+++ b/app/views/financial_transactions/_form.html.erb
@@ -64,7 +64,6 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit 'Submit Payment', class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_back 'Back', financial_transactions_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/financial_transactions/_form.html.erb
+++ b/app/views/financial_transactions/_form.html.erb
@@ -64,7 +64,7 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit 'Submit Payment', class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_to 'Back', :back, class: 'btn btn-default' %>
+      <%= link_back 'Back', financial_transactions_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -39,7 +39,7 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_to 'Back', :back, class: 'btn btn-default' %>
+      <%= link_back 'Back', groups_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -39,7 +39,6 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_back 'Back', groups_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -3,7 +3,6 @@
 
 <h5>
   <%= link_to 'Edit Group', edit_group_path(@group), class: "btn btn-primary" %>
-  <%= link_back 'Back', groups_path, class: "btn btn-default" %>
 </h5>
 
 <h3>Permissions</h3>

--- a/app/views/holds/_form.html.erb
+++ b/app/views/holds/_form.html.erb
@@ -42,7 +42,6 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_back 'Back', holds_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/holds/_form.html.erb
+++ b/app/views/holds/_form.html.erb
@@ -42,7 +42,7 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_to 'Back', :back, class: 'btn btn-default' %>
+      <%= link_back 'Back', holds_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/holds/show.html.erb
+++ b/app/views/holds/show.html.erb
@@ -33,6 +33,5 @@
 <div class="form-group col-xs-12">
   <div class="col-xs-offset-2 col-xs-10">
     <%= link_to 'Edit Hold', edit_hold_path(@hold), class: "btn btn-primary" %>
-    <%= link_back 'Back', holds_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/incidental_types/_form.html.erb
+++ b/app/views/incidental_types/_form.html.erb
@@ -30,7 +30,7 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_to 'Back', :back, class: 'btn btn-default' %>
+      <%= link_back 'Back', incidental_types_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/incidental_types/_form.html.erb
+++ b/app/views/incidental_types/_form.html.erb
@@ -30,7 +30,6 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_back 'Back', incidental_types_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/incidental_types/show.html.erb
+++ b/app/views/incidental_types/show.html.erb
@@ -18,6 +18,5 @@
 <div class="form-group col-xs-12">
   <div class="col-xs-offset-2 col-xs-10">
     <%= link_to 'Edit Incidental Type', edit_incidental_type_path(@incidental_type), class: "btn btn-primary" %>
-    <%= link_back 'Back', incidental_types_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/incurred_incidentals/_form.html.erb
+++ b/app/views/incurred_incidentals/_form.html.erb
@@ -60,7 +60,7 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_to 'Back', :back, class: 'btn btn-default' %>
+      <%= link_back 'Back', incurred_incidentals_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/incurred_incidentals/_form.html.erb
+++ b/app/views/incurred_incidentals/_form.html.erb
@@ -60,7 +60,6 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_back 'Back', incurred_incidentals_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/incurred_incidentals/show.html.erb
+++ b/app/views/incurred_incidentals/show.html.erb
@@ -119,6 +119,5 @@
       <% end %>
     <% end %>
     <%= link_to 'View Incidental Type', incidental_type_path(@incurred_incidental.incidental_type), class: "btn btn-success" %>
-    <%= link_back 'Back', incurred_incidentals_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/item_types/_form.html.erb
+++ b/app/views/item_types/_form.html.erb
@@ -23,7 +23,6 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_back 'Back', item_types_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/item_types/_form.html.erb
+++ b/app/views/item_types/_form.html.erb
@@ -23,7 +23,7 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_to 'Back', :back, class: 'btn btn-default' %>
+      <%= link_back 'Back', item_types_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/item_types/new_item_type.html.erb
+++ b/app/views/item_types/new_item_type.html.erb
@@ -26,7 +26,7 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= submit_tag 'Submit', class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_to 'Back', :back, class: 'btn btn-primary' %>
+      <%= link_back 'Back', item_types_path, class: 'btn btn-primary' %>
     </div>
   </div>
 

--- a/app/views/item_types/new_item_type.html.erb
+++ b/app/views/item_types/new_item_type.html.erb
@@ -26,7 +26,6 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= submit_tag 'Submit', class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_back 'Back', item_types_path, class: 'btn btn-primary' %>
     </div>
   </div>
 

--- a/app/views/item_types/show.html.erb
+++ b/app/views/item_types/show.html.erb
@@ -13,6 +13,5 @@
 <div class="form-group col-xs-12">
   <div class="col-xs-offset-2 col-xs-10">
     <%= link_to 'Edit Item Type', edit_item_type_path(@item_type), class: "btn btn-primary" %>
-    <%= link_back 'Back', item_types_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -19,7 +19,6 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_back 'Back', items_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -19,7 +19,7 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_to 'Back', :back, class: 'btn btn-default' %>
+      <%= link_back 'Back', items_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/items/new_item.html.erb
+++ b/app/views/items/new_item.html.erb
@@ -19,7 +19,7 @@
   <div class="form-group col-xs-12">
     <div class="col-xs-offset-2 col-xs-10">
       <%= submit_tag 'Submit', class: "btn btn-primary", data: { confirm: 'Are you sure?' } %>
-      <%= link_to 'Back', :back, class: "btn btn-primary" %>
+      <%= link_back 'Back', items_path, class: "btn btn-primary" %>
     </div>
   </div>
 

--- a/app/views/items/new_item.html.erb
+++ b/app/views/items/new_item.html.erb
@@ -19,7 +19,6 @@
   <div class="form-group col-xs-12">
     <div class="col-xs-offset-2 col-xs-10">
       <%= submit_tag 'Submit', class: "btn btn-primary", data: { confirm: 'Are you sure?' } %>
-      <%= link_back 'Back', items_path, class: "btn btn-primary" %>
     </div>
   </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -14,6 +14,5 @@
   <div class="col-xs-offset-2 col-xs-10">
     <%= link_to 'Edit Item', edit_item_path(@item), class: "btn btn-primary" %>
     <%= link_to 'Delete Item', { :controller => "items", :action => "destroy" }, method: :delete, data: { :confirm => 'Are you sure?' }, class: 'btn btn-danger' %>
-    <%= link_back 'Back', items_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/rentals/_form.html.erb
+++ b/app/views/rentals/_form.html.erb
@@ -120,7 +120,6 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', id: 'rentalSubmit', disabled: 'disabled', data: { confirm: 'Are you sure?' } %>
-      <%= link_back 'Back', rentals_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/rentals/_form.html.erb
+++ b/app/views/rentals/_form.html.erb
@@ -120,7 +120,7 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', id: 'rentalSubmit', disabled: 'disabled', data: { confirm: 'Are you sure?' } %>
-      <%= link_to 'Back', :back, class: 'btn btn-default' %>
+      <%= link_back 'Back', rentals_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/rentals/drop_off.html.erb
+++ b/app/views/rentals/drop_off.html.erb
@@ -47,7 +47,6 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit 'Drop Off', class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_to 'Back', :back, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/rentals/invoice.html.erb
+++ b/app/views/rentals/invoice.html.erb
@@ -97,7 +97,6 @@
 
   <div class="col-xs-12">
     <div class="col-xs-offset-2 col-xs-10">
-      <%= link_to 'Back', :back, class: "btn btn-default" %>
       <%= link_to 'Print Invoice', @rental, :onclick => 'window.print();return false;', class: "btn btn-primary"%>
     </div>
   </div>

--- a/app/views/rentals/no_show_form.html.erb
+++ b/app/views/rentals/no_show_form.html.erb
@@ -33,7 +33,6 @@
   <div class="form-group col-xs-12">
     <div class="col-xs-offset-2 col-xs-10">
       <%= f.submit 'Process No Show', class: "btn btn-primary", data: { confirm: 'Are you sure?' } %>
-      <%= link_to 'Back', :back, class: "btn btn-default" %>
     </div>
   </div>
 <% end %>

--- a/app/views/rentals/pickup.html.erb
+++ b/app/views/rentals/pickup.html.erb
@@ -60,7 +60,6 @@
       <% else %>
         <%= f.submit 'Pick Up', class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
       <% end %>
-      <%= link_to 'Back', :back, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/rentals/show.html.erb
+++ b/app/views/rentals/show.html.erb
@@ -76,6 +76,5 @@
     <% if @rental.balance != 0 %>
       <%= link_to 'Process Payment', new_financial_transaction_path(rental_id: @rental.id, transactable_type: Payment.name), class: "btn btn-primary"%>
     <% end %>
-    <%= link_back 'Back', rentals_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -55,7 +55,7 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_to 'Back', :back, class: 'btn btn-default' %>
+      <%= link_back 'Back', users_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -55,7 +55,6 @@
   <div class='form-group col-xs-12'>
     <div class='col-xs-offset-2 col-xs-10'>
       <%= f.submit class: 'btn btn-primary', data: { confirm: 'Are you sure?' } %>
-      <%= link_back 'Back', users_path, class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,6 +28,5 @@
 <div class="form-group col-xs-12">
   <div class="col-xs-offset-2 col-xs-10">
     <%= link_to 'Edit User', edit_user_path(@user), class: "btn btn-primary" %>
-    <%= link_back 'Back', users_path, class: "btn btn-default" %>
   </div>
 </div>

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 99.34
+    "covered_percent": 99.39
   }
 }


### PR DESCRIPTION
resolves #395 

Back buttons on forms would lead the user in a loop if an error occurs upon submitting the form.
Made use of existing `link_back` and `set_return_url` to make back button behavior more consistent.